### PR TITLE
Replace Ed with Jim

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ The ordering of rules matters. The last match will win. Set `permit=false` if yo
 For example, using the two entries below:
 
 ```
-[ed_root_du]
-name=ed
+[jim_root_du]
+name=jim
 target=root
 permit=true
 regex = ^(/usr)?/bin/du\s.*
@@ -128,8 +128,8 @@ require_pass=false
 ```
 
 ```
-[ed_postgres]
-name=ed
+[jim_postgres]
+name=jim
 target=postgres
 permit=true
 regex = /bin/bash

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Next, configure your `/etc/please.ini`, replace user names with appropriate valu
 
 ## Matches
 
-One of the simplest, that does not require password authentication can be defined as follows, assuming the user is `ed`:
+One of the simplest, that does not require password authentication can be defined as follows, assuming the user is `jim`:
 
 The options are as follows:
 

--- a/examples/please.ini
+++ b/examples/please.ini
@@ -1,22 +1,22 @@
-# permit user 'ed' to run anything
-#[ed_become_root]
-#name = ed
+# permit user 'jim' to run anything
+#[jim_become_root]
+#name = jim
 #target = root
 #regex = .*
 #require_pass = false
 #
-# permit user ed to modify the hosts file
-#[ed_hosts]
-#name = ed
+# permit user jim to modify the hosts file
+#[jim_hosts]
+#name = jim
 #type = edit
 #target = root
 #regex = /etc/hosts
 #editmode = 644
 #require_pass = false
 #
-# permit user ed to modify the /etc/please.ini and run a check on exit
-#[ed_please]
-#name = ed
+# permit user jim to modify the /etc/please.ini and run a check on exit
+#[jim_please]
+#name = jim
 #type = edit
 #target = root
 #regex = /etc/please.ini

--- a/man/please.ini.5
+++ b/man/please.ini.5
@@ -156,8 +156,8 @@ You should reduce this to the set of acceptable commands though.
 .IP
 .nf
 \f[C]
-[user_ed_root]
-name=ed
+[user_jim_root]
+name=jim
 target=root
 regex=^.*$
 \f[]
@@ -169,8 +169,8 @@ To list another user, they must match the \f[B]target\f[] regex.
 .IP
 .nf
 \f[C]
-[user_ed_list_root]
-name=ed
+[user_jim_list_root]
+name=jim
 type=list
 target=root
 \f[]
@@ -181,8 +181,8 @@ edit with \f[B]pleaseedit\f[].
 .IP
 .nf
 \f[C]
-[user_ed_edit_hosts]
-name=ed
+[user_jim_edit_hosts]
+name=jim
 type=edit
 target=root
 regex=^/etc/hosts$
@@ -231,20 +231,20 @@ Here is a sample for the above scenario:
 .IP
 .nf
 \f[C]
-[user_ed_root]
-name=ed
+[user_jim_root]
+name=jim
 target=root
 permit=true
 regex=^/usr/bin/wc\ (/var/log/[a\-zA\-Z0\-9\-]+(\\.\\d+)?(\\s)?)+$
 \f[]
 .fi
 .PP
-User ed may only start or stop a docker container:
+User jim may only start or stop a docker container:
 .IP
 .nf
 \f[C]
-[user_ed_root]
-name=ed
+[user_jim_root]
+name=jim
 target=root
 permit=true
 regex=^/usr/bin/docker\ (start|stop)\ \\S+

--- a/please.ini.md
+++ b/please.ini.md
@@ -96,8 +96,8 @@ Spaces within arguments will be substituted as **'\\\ '** (backslash space). Use
 To allow all commands, you can use a greedy match (**^.\*$**). You should reduce this to the set of acceptable commands though.
 
 ```
-[user_ed_root]
-name=ed
+[user_jim_root]
+name=jim
 target=root
 regex=^.*$
 ```
@@ -105,8 +105,8 @@ regex=^.*$
 If you wish to permit a user to view another's command set, then you may do this using **type=list** (**run** by default). To list another user, they must match the **target** regex.
 
 ```
-[user_ed_list_root]
-name=ed
+[user_jim_list_root]
+name=jim
 type=list
 target=root
 ```
@@ -114,8 +114,8 @@ target=root
 **type** may also be **edit** if you wish to permit a file edit with **pleaseedit**.
 
 ```
-[user_ed_edit_hosts]
-name=ed
+[user_jim_edit_hosts]
+name=jim
 type=edit
 target=root
 regex=^/etc/hosts$
@@ -147,18 +147,18 @@ $ find /var/log -type f -exec please /usr/bin/wc {} \+
 Here is a sample for the above scenario:
 
 ```
-[user_ed_root]
-name=ed
+[user_jim_root]
+name=jim
 target=root
 permit=true
 regex=^/usr/bin/wc (/var/log/[a-zA-Z0-9-]+(\.\d+)?(\s)?)+$
 ```
 
-User ed may only start or stop a docker container:
+User jim may only start or stop a docker container:
 
 ```
-[user_ed_root]
-name=ed
+[user_jim_root]
+name=jim
 target=root
 permit=true
 regex=^/usr/bin/docker (start|stop) \S+
@@ -308,12 +308,12 @@ For simplicity, there is no need to process other configured rules if certain th
 
 # SYSLOG
 
-By default entries are logged to syslog. If you do not wish an entry to go logged then specify **syslog=false**. Use this only if you are happy with commands going unlogged, simialr to if policy would permit the user to switch to the target account.
+By default entries are logged to syslog. If you do not wish an entry to go logged then specify **syslog=false**. Use this only if you are happy with commands going unlogged, similar to if policy would permit the user to switch to the target account.
 
 ```
 [maverick]
 syslog = false
-name = ed
+name = jim
 regex = /usr/bin/.*
 reason = false
 ```


### PR DESCRIPTION
As beautiful a name as it is, Ed is a poor user example. 

Say Jim wants to play around with please. He copy and pastes some examples and uses his text editor to search and replace all instances of `ed` with `jim`.

Now he has inadvertently also replaced the `ed` in `edit` with `jim`. `pleaseedit` becomes `pleasejimit`.   